### PR TITLE
update comment for instruction `0xE15FF000` in ARM tests

### DIFF
--- a/arm/data_processing.asm
+++ b/arm/data_processing.asm
@@ -480,7 +480,7 @@ t234:
         msr     cpsr, MODE_FIQ
         mov     r8, 64
         msr     spsr, MODE_SYS
-        dw      0xE15FF000  ; cmp pc, pc
+        dw      0xE15FF000  ; cmp pc, pc, r0
         nop
         nop
         beq     f234
@@ -495,7 +495,7 @@ f234:
 t235:
         ; ARM 3: Bad CMP / CMN / TST / TEQ do not flush the pipeline
         mov     r8, 0
-        dw      0xE15FF000  ; cmp pc, pc
+        dw      0xE15FF000  ; cmp pc, pc, r0
         mov     r8, 1
         nop
         cmp     r8, 0


### PR DESCRIPTION
This pull request contains a small update to the documentation for the ARM tests t234 and t235. It changes the comment for instruction `0xE15FF000` to match the instruction itself, as specified for ARMv4T (`cmp pc, pc` -> `cmp pc, r0`).

First, I also wanted to ask whether  `cmp pc, r0` is the intended instruction to be tested  (instead of `cmp pc, pc` / `0xE15FF00F`).